### PR TITLE
Update Connection.groovy

### DIFF
--- a/src/groovy/grails/plugins/raven/Connection.groovy
+++ b/src/groovy/grails/plugins/raven/Connection.groovy
@@ -35,17 +35,35 @@ public class Connection {
     public void send(String messageBody, long timestamp) throws IOException {
         String hmacSignature = getSignature("$timestamp $messageBody", config.secretKey)
 
-        HttpURLConnection connection = getConnection()
-        connection.setRequestMethod("POST")
-        connection.setDoOutput(true)
-        connection.setReadTimeout(10000)
-        connection.setRequestProperty("X-Sentry-Auth", buildAuthHeader(hmacSignature, timestamp, config.publicKey))
-        OutputStream output = connection.getOutputStream()
-        output.write(messageBody.getBytes())
-        output.close()
-        connection.connect()
-        InputStream input = connection.getInputStream()
-        input.close()
+        Executors.newCachedThreadPool().execute(new Runnable() {
+            @Override
+            void run() {
+                HttpURLConnection connection = null
+                try {
+                    connection = getConnection()
+                    connection.setRequestMethod("POST")
+                    connection.setDoOutput(true)
+                    connection.setReadTimeout(5000)
+                    connection.setConnectTimeout(5000)
+                    connection.setRequestProperty("X-Sentry-Auth", buildAuthHeader(hmacSignature, timestamp, config.publicKey))
+                    OutputStream output = connection.getOutputStream()
+                    output.write(messageBody.getBytes())
+                    output.close()
+                    connection.connect()
+                    InputStream input = connection.getInputStream()
+                    input.close()
+                } catch ( IOException e ) {
+                    if (connection != null) {
+                        try {
+                            connection.disconnect()
+                        } catch ( Exception e2 ) {
+                            //ignore bad disconnect
+                        }
+                    }
+                    throw e
+                }
+            }
+        })
     }
 
     private String buildAuthHeader(String hmacSignature, long timestamp, String publicKey) {


### PR DESCRIPTION
We had an issue with our Sentry server (separate server from the clustered app server) was not accessible over our network. When this issue occurred, and many errors were occurring on the app server, the number of HTTPURLConnection's available in the "send" method became limited and the network connect timeout time, quite being long, caused the app servers to eventually  lockup completely.

Using shorter timeouts and doing the actual work in "send" asynchronously seemed like a reasonable fix. We have tested this solution and are satisfied with the results. Hope this fix may be of use to someone else and/or an alternate/better solution can be suggested.
